### PR TITLE
チャット自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(function(){
      function buildHTML(message){
       if ( message.image ) {
         var html = 
-         `<div class ="chat-main__messages__box">
+         `<div class ="chat-main__messages__box  data-message-id=${message.id}">
             <div class ="chat-main__messages__box__up">
               <div class ="chat-main__messages__box__up__title">
                 ${message.user_name}
@@ -22,7 +22,7 @@ $(function(){
         return html;
       } else {
         var html =
-         `<div class ="chat-main__messages__box">
+         `<div class ="chat-main__messages__box  data-message-id=${message.id}">
             <div class ="chat-main__messages__box__up">
               <div class ="chat-main__messages__box__up__title">
                 ${message.user_name}

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,4 @@
 $(function(){
-  var last_message_id = $('.chat-main__messages__box:last').data("message-id");
-  console.log(last_message_id);
  
      function buildHTML(message){
       if ( message.image ) {
@@ -67,4 +65,25 @@ $("#new_message").on("submit", function(e){
       $('.submit-btn').prop('disabled', false);
     })
     })
+
+    var reloadMessages = function() {
+      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      var last_message_id = $('.chat-main__messages__box:last').data("message-id");
+      $.ajax({
+        //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+        url: "api/messages",
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        console.log('success');
+      })
+      .fail(function() {
+        alert('error');
+      });
+    };
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -80,20 +80,22 @@ $("#new_message").on("submit", function(e){
       })
       .done(function(messages) {
         if (messages.length !== 0) {
-      //追加するHTMLの入れ物を作る
-      var insertHTML = '';
-      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
-      $.each(messages, function(i, message) {
-        insertHTML += buildHTML(message)
-      });
-      //メッセージが入ったHTMLに、入れ物ごと追加
-      $('.messages').append(insertHTML);
-      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-    }
+          //追加するHTMLの入れ物を作る
+          var insertHTML = '';
+          //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+          $.each(messages, function(i, message) {
+            insertHTML += buildHTML(message)
+          });
+          //メッセージが入ったHTMLに、入れ物ごと追加
+          $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        }
       })
       .fail(function() {
         alert('error');
       });
     };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
     setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -79,7 +79,14 @@ $("#new_message").on("submit", function(e){
         data: {id: last_message_id}
       })
       .done(function(messages) {
-        console.log('success');
+      //追加するHTMLの入れ物を作る
+      var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      //メッセージが入ったHTMLに、入れ物ごと追加
+      $('.messages').append(insertHTML);
       })
       .fail(function() {
         alert('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -79,6 +79,7 @@ $("#new_message").on("submit", function(e){
         data: {id: last_message_id}
       })
       .done(function(messages) {
+        if (messages.length !== 0) {
       //追加するHTMLの入れ物を作る
       var insertHTML = '';
       //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
@@ -87,6 +88,8 @@ $("#new_message").on("submit", function(e){
       });
       //メッセージが入ったHTMLに、入れ物ごと追加
       $('.messages').append(insertHTML);
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+    }
       })
       .fail(function() {
         alert('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -92,5 +92,5 @@ $("#new_message").on("submit", function(e){
         alert('error');
       });
     };
-
+    setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(function(){
      function buildHTML(message){
       if ( message.image ) {
         var html = 
-         `<div class ="chat-main__messages__box  data-message-id=${message.id}">
+         `<div class ="chat-main__messages__box" data-message-id=${message.id}>
             <div class ="chat-main__messages__box__up">
               <div class ="chat-main__messages__box__up__title">
                 ${message.user_name}
@@ -22,7 +22,7 @@ $(function(){
         return html;
       } else {
         var html =
-         `<div class ="chat-main__messages__box  data-message-id=${message.id}">
+         `<div class ="chat-main__messages__box"  data-message-id=${message.id}>
             <div class ="chat-main__messages__box__up">
               <div class ="chat-main__messages__box__up__title">
                 ${message.user_name}
@@ -67,28 +67,21 @@ $("#new_message").on("submit", function(e){
     })
 
     var reloadMessages = function() {
-      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
       var last_message_id = $('.chat-main__messages__box:last').data("message-id");
       $.ajax({
-        //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
         url: "api/messages",
-        //ルーティングで設定した通りhttpメソッドをgetに指定
         type: 'get',
         dataType: 'json',
-        //dataオプションでリクエストに値を含める
         data: {id: last_message_id}
       })
       .done(function(messages) {
         if (messages.length !== 0) {
-          //追加するHTMLの入れ物を作る
           var insertHTML = '';
-          //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
           $.each(messages, function(i, message) {
             insertHTML += buildHTML(message)
           });
-          //メッセージが入ったHTMLに、入れ物ごと追加
-          $('.messages').append(insertHTML);
-          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+          $('.chat-main__messages').append(insertHTML);
+          $('.chat-main__messages').animate({ scrollTop: $('.chat-main__messages')[0].scrollHeight});
         }
       })
       .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,7 @@
 $(function(){
+  var last_message_id = $('.chat-main__messages__box:last').data("message-id");
+  console.log(last_message_id);
+ 
      function buildHTML(message){
       if ( message.image ) {
         var html = 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -21,8 +21,6 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      -# = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member
           %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat-main__messages__box
+.chat-main__messages__box{data: {message: {id: message.id}}}
   .chat-main__messages__box__up
     .chat-main__messages__box__up__title
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :groups, only: [:index, :new, :create, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,5 @@ Rails.application.routes.draw do
   resources :groups, only: [:index, :new, :create, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-    # namespace :api do
-    #   resources :messages, only: :index, defaults: { format: 'json' }
   end
 end


### PR DESCRIPTION
# What
1. メッセージにidを付与
2. 新規投稿の取得設定
APIとして機能するコントローラーを作成し、アクションとルーティングを設定
3. idを付与したメッセージを json形式でレスポンスできるよう設定
4. 取得した投稿データを表示できるよう設定
取得した最新のメッセージをブラウザのメッセージ一覧に追加
数秒ごとにリクエストするように実装

5. メッセージを取得したら画面がスクロールするよう設定
6. 自動更新が不要な画面では行わないよう設定

# Why
チャット自動更新機能実装
https://master.tech-camp.in/curriculums/1211
![自動更新テスト](https://user-images.githubusercontent.com/65595354/83490635-5b0bef00-a4eb-11ea-951a-146ee15ac7ae.gif)